### PR TITLE
Add robots*.txt handler 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2083,8 +2083,7 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -2108,8 +2107,7 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",

--- a/src/middleware/robotsText.ts
+++ b/src/middleware/robotsText.ts
@@ -1,0 +1,20 @@
+/**
+ * Handles /robots*.txt requests
+ * App Service sends a warmup request of /robots8327.txt (where 8327 is a random number)
+ * this causes a 404 error which appears in Azure Monitor as a false issue
+ * this also handles a real /robots.txt request to prevent indexing
+ */
+export function robotsHandler(req: any, res: any, next) {
+    const robotsResponse = "# Prevent indexing\r\nUser-agent: *\r\nDisallow: /\r\n";
+    const path: string = req.url.substring(1);
+
+    if (!path.includes("/") && path.toLocaleLowerCase().startsWith("robots") && path.toLocaleLowerCase().endsWith(".txt") ) {
+        res.writeHead(200, {
+            "Content-Length": Buffer.byteLength(robotsResponse),
+            "Content-Type": "text/plain",
+        });
+        res.write(robotsResponse);
+    } else {
+        next();
+    }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,26 +1,27 @@
-// import { telemetryTypeToBaseType } from "applicationinsights/out/Declarations/Contracts";
 import * as bodyParser from "body-parser";
-import { Container } from "inversify";
-import { interfaces, InversifyRestifyServer, TYPE } from "inversify-restify-utils";
-import "reflect-metadata";
 import * as swaggerJSDoc from "swagger-jsdoc";
+import EndpointLogger from "./middleware/EndpointLogger";
 import { ActorController } from "./app/controllers/actor";
+import { AppInsightsProvider } from "./telem/appinsightsprovider";
+import { BunyanLogger } from "./logging/bunyanLogProvider";
+import { Container } from "inversify";
+import { CosmosDBProvider } from "./db/cosmosdbprovider";
 import { FeaturedController } from "./app/controllers/featured";
 import { GenreController } from "./app/controllers/genre";
-import { MovieController } from "./app/controllers/movie";
-import { HealthzController } from "./app/controllers/healthz";
-import { CosmosDBProvider } from "./db/cosmosdbprovider";
-import { IDatabaseProvider } from "./db/idatabaseprovider";
-import { BunyanLogger } from "./logging/bunyanLogProvider";
-import { ILoggingProvider } from "./logging/iLoggingProvider";
-import { AppInsightsProvider } from "./telem/appinsightsprovider";
-import { ITelemProvider } from "./telem/itelemprovider";
-import EndpointLogger from "./middleware/EndpointLogger";
 import { getConfigValues } from "./config/config";
+import { HealthzController } from "./app/controllers/healthz";
 import { html } from "./swagger-html";
+import { IDatabaseProvider } from "./db/idatabaseprovider";
+import { ILoggingProvider } from "./logging/iLoggingProvider";
+import { interfaces, InversifyRestifyServer, TYPE } from "inversify-restify-utils";
+import { ITelemProvider } from "./telem/itelemprovider";
+import { MovieController } from "./app/controllers/movie";
+import { robotsHandler } from "./middleware/robotsText";
+import "reflect-metadata";
 
 (async () => {
     const restify = require("restify");
+
     /**
      * Create an Inversion of Control container using Inversify
      */
@@ -70,6 +71,8 @@ import { html } from "./swagger-html";
              */
             app.use(bodyParser.urlencoded({ extended: true }));
 
+            app.pre(robotsHandler);
+
             /**
              * Parses HTTP query string and makes it available in req.query.
              * Setting mapParams to false prevents additional params in query to be merged in req.Params
@@ -101,7 +104,7 @@ import { html } from "./swagger-html";
                         title: "Helium", // Title (required)
                         version: "1.0.1", // Version (required)
                     },
-                    openapi: "3.0.2", // Specification (optional, defaults to swagger: '2.0')
+                    openapi: "3.0.2", // Specification (optional, defaults to swagger: "2.0")
                 },
             };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import * as bodyParser from "body-parser";
 import * as swaggerJSDoc from "swagger-jsdoc";
+import "reflect-metadata";
 import EndpointLogger from "./middleware/EndpointLogger";
 import { ActorController } from "./app/controllers/actor";
 import { AppInsightsProvider } from "./telem/appinsightsprovider";
@@ -17,7 +18,6 @@ import { interfaces, InversifyRestifyServer, TYPE } from "inversify-restify-util
 import { ITelemProvider } from "./telem/itelemprovider";
 import { MovieController } from "./app/controllers/movie";
 import { robotsHandler } from "./middleware/robotsText";
-import "reflect-metadata";
 
 (async () => {
     const restify = require("restify");


### PR DESCRIPTION
Closes https://github.com/retaildevcrews/helium-typescript/issues/1 

- Added robots*.txt handler 
- Sorted imports in server.ts
- Tested locally, in App Services and with integration test. 