### PR TITLE
Updating to version 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "helium",
-  "version": "1.0.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helium",
-  "version": "1.0.0",
+  "version": "0.5.0",
   "description": "Azure App Service reference application.",
   "main": "dist/server.js",
   "directories": {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -8,6 +8,7 @@ export const appInsightsKey = "AppInsightsKey";
 export const portConstant = "4120";
 
 export const webInstanceRole = "WEBSITE_ROLE_INSTANCE_ID";
+export const version = process.env.npm_package_version;
 
 export const defaultPageSize = 100;
 export const maxPageSize = 1000;

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { interfaces, InversifyRestifyServer, TYPE } from "inversify-restify-util
 import { ITelemProvider } from "./telem/itelemprovider";
 import { MovieController } from "./app/controllers/movie";
 import { robotsHandler } from "./middleware/robotsText";
+import { version } from "./config/constants";
 
 (async () => {
     const restify = require("restify");
@@ -102,7 +103,7 @@ import { robotsHandler } from "./middleware/robotsText";
                 definition: {
                     info: {
                         title: "Helium", // Title (required)
-                        version: "1.0.1", // Version (required)
+                        version: {version}, // Version (required)
                     },
                     openapi: "3.0.2", // Specification (optional, defaults to swagger: "2.0")
                 },


### PR DESCRIPTION
Closes #17 

**What this PR does / why we need it**:
Updates version to 0.5.0 for M5.  (0.5.0.0 is invalid)

**Special notes for your reviewer**:
- Holding off on adding date/time until later change/ SMKer can advise on best way to determine build time. 
- I am intentionally not updating Healthz version as that will be changed completely with healthz updates. 
