### PR TITLE
Initializing cosmos provider at app start

### DIFF
--- a/src/db/cosmosdbprovider.ts
+++ b/src/db/cosmosdbprovider.ts
@@ -40,7 +40,7 @@ export class CosmosDBProvider {
      * Initialize the Cosmos DB Container.
      * This is handled in a separate method to avoid calling async operations in the constructor.
      */
-    private async _initialize() {
+    public async initialize() {
 
         this.logger.Trace("Initializing CosmosDB Container");
         this.cosmosContainer = await this.cosmosClient.database(this.databaseId).container(this.containerId);
@@ -51,15 +51,6 @@ export class CosmosDBProvider {
      * @param query The query to select the documents.
      */
     public async queryDocuments(query: string): Promise<any[]> {
-        // Initialize if not already set up
-        // TODO: Move this initialization to server.ts as this degrades initial query performance
-        if (this.cosmosContainer == null) {
-            try {
-                await this._initialize();
-            } catch (e) {
-                this.logger.Trace("No Cosmos setup: " + e);
-            }
-        }
         // Wrap all functionality in a promise to avoid forcing the caller to use callbacks
         return new Promise(async (resolve, reject) => {
             const { resources: queryResults } = await this.cosmosContainer.items.query(query, this.feedOptions).fetchAll();
@@ -76,15 +67,6 @@ export class CosmosDBProvider {
      */
     public async getDocument(partitionKey: string,
                              documentId: string): Promise<any> {
-        // Initialize if not already set up
-        // TODO: Move this initialization to server.ts as this degrades initial query performance
-        if (this.cosmosContainer == null) {
-            try {
-                await this._initialize();
-            } catch (e) {
-                this.logger.Trace("No Cosmos setup: " + e);
-            }
-        }
 
         return new Promise(async (resolve, reject) => {
             const { resource: result, statusCode: status } = await this.cosmosContainer.item(documentId, partitionKey).read();

--- a/src/db/idatabaseprovider.ts
+++ b/src/db/idatabaseprovider.ts
@@ -1,5 +1,11 @@
 export interface IDatabaseProvider {
     /**
+     * Initialize the Cosmos DB Container.
+     * This is handled in a separate method to avoid calling async operations in the constructor.
+     */
+    initialize();
+
+    /**
      * Runs the given query against CosmosDB.
      * @param query The query to select the documents.
      */

--- a/src/server.ts
+++ b/src/server.ts
@@ -64,8 +64,9 @@ import { version } from "./config/constants";
     try {
         await cosmosDb.initialize();
     } catch (err) {
-        log.Trace("Cosmos failed to initialize: " + err);
+        log.Error(Error(err), "Cosmos failed to initialize: " + err);
     }
+
     // create restify server
     const server = new InversifyRestifyServer(iocContainer);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,6 +59,13 @@ import { version } from "./config/constants";
     iocContainer.bind<ITelemProvider>("ITelemProvider").to(AppInsightsProvider).inSingletonScope();
     const telem: ITelemProvider = iocContainer.get<ITelemProvider>("ITelemProvider");
 
+    // initialize cosmos db provider
+    const cosmosDb: IDatabaseProvider = iocContainer.get<IDatabaseProvider>("IDatabaseProvider");
+    try {
+        await cosmosDb.initialize();
+    } catch (err) {
+        log.Trace("Cosmos failed to initialize: " + err);
+    }
     // create restify server
     const server = new InversifyRestifyServer(iocContainer);
 


### PR DESCRIPTION
Closes #32 

**What this PR does / why we need it**:
- Moves Cosmos DB provider initialization to app start up (was previously done with first request/query) to improve performance of first query.

