### PR TITLE
Healthz Query Refactoring Pt. 1: Move get partition key function out of controller

### DIFF
--- a/src/app/controllers/actor.ts
+++ b/src/app/controllers/actor.ts
@@ -5,7 +5,6 @@ import * as HttpStatus from "http-status-codes";
 import { IDatabaseProvider } from "../../db/idatabaseprovider";
 import { ILoggingProvider } from "../../logging/iLoggingProvider";
 import { ITelemProvider } from "../../telem/itelemprovider";
-import { QueryUtilities } from "../../utilities/queryUtilities";
 import { Actor } from "../models/actor";
 import { defaultPageSize, maxPageSize } from "../../config/constants";
 
@@ -151,9 +150,7 @@ export class ActorController implements interfaces.Controller {
         let resCode: number = HttpStatus.OK;
         let result: Actor;
         try {
-            result = await this.cosmosDb.getDocument(
-                QueryUtilities.getPartitionKey(actorId),
-                actorId);
+            result = await this.cosmosDb.getDocument(actorId);
         } catch (err) {
             result = err.toString();
 

--- a/src/app/controllers/featured.ts
+++ b/src/app/controllers/featured.ts
@@ -4,7 +4,6 @@ import * as HttpStatus from "http-status-codes";
 import { IDatabaseProvider } from "../../db/idatabaseprovider";
 import { ILoggingProvider } from "../../logging/iLoggingProvider";
 import { ITelemProvider } from "../../telem/itelemprovider";
-import { QueryUtilities } from "../../utilities/queryUtilities";
 import { Movie } from "../models/movie";
 
 /**
@@ -56,9 +55,7 @@ export class FeaturedController implements interfaces.Controller {
 
             if (this._featuredMovies != null && this._featuredMovies.length > 0 ) {
                 const movieId = this._featuredMovies[ Math.floor(Math.random() * ( this._featuredMovies.length - 1 )) ];
-                result = await this.cosmosDb.getDocument(
-                    QueryUtilities.getPartitionKey(movieId),
-                    movieId);
+                result = await this.cosmosDb.getDocument(movieId);
             }
         } catch (err) {
             if (err.toString().includes("NotFound")) {

--- a/src/app/controllers/movie.ts
+++ b/src/app/controllers/movie.ts
@@ -4,7 +4,6 @@ import * as HttpStatus from "http-status-codes";
 import { IDatabaseProvider } from "../../db/idatabaseprovider";
 import { ILoggingProvider } from "../../logging/iLoggingProvider";
 import { ITelemProvider } from "../../telem/itelemprovider";
-import { QueryUtilities } from "../../utilities/queryUtilities";
 import { defaultPageSize, maxPageSize } from "../../config/constants";
 import { Movie } from "../models/movie";
 
@@ -213,9 +212,7 @@ export class MovieController implements interfaces.Controller {
         let resCode: number = HttpStatus.OK;
         let result: Movie;
         try {
-            result = await this.cosmosDb.getDocument(
-                QueryUtilities.getPartitionKey(movieId),
-                movieId);
+            result = await this.cosmosDb.getDocument(movieId);
         } catch (err) {
             result = err.toString();
 

--- a/src/db/cosmosdbprovider.ts
+++ b/src/db/cosmosdbprovider.ts
@@ -1,6 +1,7 @@
 import { CosmosClient, Container, FeedOptions } from "@azure/cosmos";
 import { inject, injectable, named } from "inversify";
 import { ILoggingProvider } from "../logging/iLoggingProvider";
+import { QueryUtilities } from "../utilities/queryUtilities";
 
 /**
  * Handles executing queries against CosmosDB
@@ -62,14 +63,13 @@ export class CosmosDBProvider {
 
     /**
      * Retrieves a specific document by Id.
-     * @param partitionKey The partition key for the document.
      * @param documentId The id of the document to query.
      */
-    public async getDocument(partitionKey: string,
-                             documentId: string): Promise<any> {
+    public async getDocument(documentId: string): Promise<any> {
 
         return new Promise(async (resolve, reject) => {
-            const { resource: result, statusCode: status } = await this.cosmosContainer.item(documentId, partitionKey).read();
+            const { resource: result, statusCode: status } =
+                await this.cosmosContainer.item(documentId, QueryUtilities.getPartitionKey(documentId)).read();
             if (status === 200) {
                 resolve(result);
             } else {

--- a/src/db/idatabaseprovider.ts
+++ b/src/db/idatabaseprovider.ts
@@ -13,8 +13,7 @@ export interface IDatabaseProvider {
 
     /**
      * Retrieves a specific document by Id.
-     * @param partitionKey The partition key for the document.
      * @param documentId The id of the document to query.
      */
-    getDocument(partitionKey: string, documentId: string): Promise<any>;
+    getDocument(documentId: string): Promise<any>;
 }


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- This is part of the refactoring work needed for #19 and #31.  The refactoring work is to move the query logic out of the Controllers, this will allow for much less duplicated code when implementing the new healthz endpoints. 
- This PR specifically moves getting the partition key to the db provider, instead of in each controller. 

## Review notes
- Separating this out to make reviewing easier, next change will move the rest of the query logic (i.e. sql query building) to the db provider.  

## Issues Closed or Referenced
- References #19 and #31
