### PR TITLE
Healthz Query Refactoring Pt. 2: Move query logic out of controllers

### DIFF
--- a/src/app/controllers/actor.ts
+++ b/src/app/controllers/actor.ts
@@ -6,7 +6,6 @@ import { IDatabaseProvider } from "../../db/idatabaseprovider";
 import { ILoggingProvider } from "../../logging/iLoggingProvider";
 import { ITelemProvider } from "../../telem/itelemprovider";
 import { Actor } from "../models/actor";
-import { defaultPageSize, maxPageSize } from "../../config/constants";
 
 // Controller implementation for our actors endpoint
 @Controller("/api/actors")

--- a/src/app/controllers/genre.ts
+++ b/src/app/controllers/genre.ts
@@ -5,6 +5,7 @@ import * as HttpStatus from "http-status-codes";
 import { IDatabaseProvider } from "../../db/idatabaseprovider";
 import { ILoggingProvider } from "../../logging/iLoggingProvider";
 import { ITelemProvider } from "../../telem/itelemprovider";
+import { sqlGenres } from "../../config/constants";
 
 /**
  * controller implementation for our genres endpoint
@@ -12,8 +13,6 @@ import { ITelemProvider } from "../../telem/itelemprovider";
 @Controller("/api/genres")
 @injectable()
 export class GenreController implements interfaces.Controller {
-
-  private readonly _sql: string = "SELECT VALUE root.id FROM root where root.type = 'Genre'";
 
   constructor(@inject("IDatabaseProvider") private cosmosDb: IDatabaseProvider,
               @inject("ITelemProvider") private telem: ITelemProvider,
@@ -48,7 +47,7 @@ export class GenreController implements interfaces.Controller {
     let resCode: number = HttpStatus.OK;
     let results: string[];
     try {
-      results = await this.cosmosDb.queryDocuments(this._sql);
+      results = await this.cosmosDb.queryDocuments(sqlGenres);
     } catch (err) {
       resCode = HttpStatus.INTERNAL_SERVER_ERROR;
     }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -13,4 +13,4 @@ export const version = process.env.npm_package_version;
 export const defaultPageSize = 100;
 export const maxPageSize = 1000;
 
-export const sqlGenres = "SELECT VALUE root.id FROM root where root.type = 'Genre'";
+export const sqlGenres = "SELECT VALUE m.id FROM m where m.type = 'Genre'";

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -12,3 +12,5 @@ export const version = process.env.npm_package_version;
 
 export const defaultPageSize = 100;
 export const maxPageSize = 1000;
+
+export const sqlGenres = "SELECT VALUE root.id FROM root where root.type = 'Genre'";

--- a/src/db/idatabaseprovider.ts
+++ b/src/db/idatabaseprovider.ts
@@ -22,4 +22,10 @@ export interface IDatabaseProvider {
      * @param queryParams The query params used to select the actor documents.
      */
     queryActors(queryParams: any): Promise<any[]>;
+
+    /**
+     * Runs the given query for movies against the database.
+     * @param queryParams The query params used to select the movie documents.
+     */
+    queryMovies(queryParams: any): Promise<any[]>;
 }

--- a/src/db/idatabaseprovider.ts
+++ b/src/db/idatabaseprovider.ts
@@ -16,4 +16,10 @@ export interface IDatabaseProvider {
      * @param documentId The id of the document to query.
      */
     getDocument(documentId: string): Promise<any>;
+
+    /**
+     * Runs the given query for actors against the database.
+     * @param queryParams The query params used to select the actor documents.
+     */
+    queryActors(queryParams: any): Promise<any[]>;
 }


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

- This is part of the refactoring work needed for #19 and #31 that allows for much less duplicated code when implementing the new healthz endpoints. 
- This PR specifically moves the sql query building logic out of the controllers. 

## Issues Closed or Referenced

- References #19 and #31
