### PR TITLE
Add /version and dynamic versioning

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,3 +1,5 @@
+import { VersionUtilities } from "../utilities/versionUtilities";
+
 export const keyVaultName = "KeyVaultName";
 export const cosmosUrl = "CosmosUrl";
 export const cosmosKey = "CosmosKey";
@@ -8,7 +10,8 @@ export const appInsightsKey = "AppInsightsKey";
 export const portConstant = "4120";
 
 export const webInstanceRole = "WEBSITE_ROLE_INSTANCE_ID";
-export const version = process.env.npm_package_version;
+
+export const version = VersionUtilities.getBuildVersion();
 
 export const defaultPageSize = 100;
 export const maxPageSize = 1000;

--- a/src/server.ts
+++ b/src/server.ts
@@ -137,6 +137,11 @@ import { version } from "./config/constants";
             app.get("/node_modules/swagger-ui-dist/*", restify.plugins.serveStatic({
                 directory: __dirname + "/..",
             }));
+
+            app.get("/version", (req, res) => {
+                res.setHeader("Content-Type", "text/plain");
+                res.send(version);
+            });
         }).build().listen(config.port, () => {
             log.Trace("Server is listening on port " + config.port);
             telem.trackEvent("API Server: Server started on port " + config.port);

--- a/src/utilities/versionUtilities.ts
+++ b/src/utilities/versionUtilities.ts
@@ -1,0 +1,22 @@
+/**
+ * Utilities for determining build version.
+ */
+import * as fs from "fs";
+
+export class VersionUtilities {
+
+    // build and return the version string based on last build date time
+    // build time based on dist/server.js file
+    public static getBuildVersion(): string {
+        const lastBuildTime = fs.statSync("./dist/server.js").mtime.toISOString();
+
+        // remove trailing "0" from package.json version
+        let version = process.env.npm_package_version.substring(0, 4);
+
+        // add "MMdd.HHmm"
+        version = version + lastBuildTime.substring(5, 7) + lastBuildTime.substring(8, 10)
+                  + "." + lastBuildTime.substring(11, 13) + lastBuildTime.substring(14, 16);
+
+        return version;
+    }
+}


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- Implement /version endpoint
- Implement dynamic versioning to add "MMdd.HHmm" of build time to version string

## Review notes
- Squeezed in the dynamic versioning as it wasn't a big change and was directly related to the version endpoint
- I used substring to build the MMdd.HHmm to avoid importing another library/package
- As far as I could tell, dist/server.js is the best reference for last build.  

## Issues Closed or Referenced

- Closes #40 
- Closes #8 
