### PR TITLE
Update handling of missing secrets

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -20,7 +20,6 @@ export async function getConfigValues(
     let cosmosDbUrl: string;
     let database: string;
     let collection: string;
-    // insightsKey comes from KeyVault
     let insightsKey: string;
 
     let keyVaultUrl: string = process.env[keyVaultName];
@@ -34,10 +33,10 @@ export async function getConfigValues(
     }
 
     const keyvault: KeyVaultProvider = new KeyVaultProvider(keyVaultUrl, log);
+
+    // get Cosmos DB related secrets
     try {
         cosmosDbKey = await keyvault.getSecret(cosmosKey);
-
-        insightsKey = await keyvault.getSecret(appInsightsKey);
 
         cosmosDbUrl = await keyvault.getSecret(cosmosUrl);
 
@@ -45,7 +44,15 @@ export async function getConfigValues(
 
         collection = await keyvault.getSecret(cosmosCollection);
     } catch {
-        log.Error(Error(), "Failed to get secrets from KeyVault. Falling back to env vars for secrets");
+        log.Error(Error(), "Failed to get required Cosmos DB secrets from KeyVault");
+        process.exit(1);
+    }
+
+    // get optional App Insights Key
+    try {
+        insightsKey = await keyvault.getSecret(appInsightsKey);
+    } catch {
+        log.Trace("Application Insights key not set.");
     }
 
     return {

--- a/src/utilities/queryUtilities.ts
+++ b/src/utilities/queryUtilities.ts
@@ -13,7 +13,7 @@ export class QueryUtilities {
             idInt = parseInt(id.substring(2), 10);
             return isNaN(idInt) ? "0" : (idInt % 10).toString();
         }
-        
+
         return idInt.toString();
     }
 }


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- Fix bug where the app was failing to run if no app insights key was set in key vault.  The expected behavior is for App Insights to be optional
- Changes also update the behavior so that the app fails to run if any of the Cosmos DB-related secrets are not found.  

- Merged with master to fix linting bug: https://github.com/retaildevcrews/helium-typescript/runs/453923027

## Review notes
- I tested this locally and in App Services to verify it works as expected.
- I created #59 to remove the telem object that is logging custom telemetry metrics as this is not needed (out of scope) and not being used.  I will remove that in a separate PR. 

## Issues Closed or Referenced

- Closes #56 
