### PR TITLE
Removed unused telemetry/logging

### DIFF
--- a/src/app/controllers/actor.ts
+++ b/src/app/controllers/actor.ts
@@ -4,7 +4,6 @@ import { Request } from "restify";
 import * as HttpStatus from "http-status-codes";
 import { IDatabaseProvider } from "../../db/idatabaseprovider";
 import { ILoggingProvider } from "../../logging/iLoggingProvider";
-import { ITelemProvider } from "../../telem/itelemprovider";
 import { Actor } from "../models/actor";
 
 // Controller implementation for our actors endpoint
@@ -14,10 +13,8 @@ export class ActorController implements interfaces.Controller {
 
     // Instantiate the actor controller
     constructor(@inject("IDatabaseProvider") private cosmosDb: IDatabaseProvider,
-                @inject("ITelemProvider") private telem: ITelemProvider,
                 @inject("ILoggingProvider") private logger: ILoggingProvider) {
         this.cosmosDb = cosmosDb;
-        this.telem = telem;
         this.logger = logger;
     }
 

--- a/src/app/controllers/featured.ts
+++ b/src/app/controllers/featured.ts
@@ -3,7 +3,6 @@ import { Controller, Get, interfaces } from "inversify-restify-utils";
 import * as HttpStatus from "http-status-codes";
 import { IDatabaseProvider } from "../../db/idatabaseprovider";
 import { ILoggingProvider } from "../../logging/iLoggingProvider";
-import { ITelemProvider } from "../../telem/itelemprovider";
 import { Movie } from "../models/movie";
 
 /**
@@ -16,10 +15,8 @@ export class FeaturedController implements interfaces.Controller {
     private _featuredMovies: string[];
 
     constructor(@inject("IDatabaseProvider") private cosmosDb: IDatabaseProvider,
-                @inject("ITelemProvider") private telem: ITelemProvider,
                 @inject("ILoggingProvider") private logger: ILoggingProvider) {
         this.cosmosDb = cosmosDb;
-        this.telem = telem;
         this.logger = logger;
     }
 

--- a/src/app/controllers/genre.ts
+++ b/src/app/controllers/genre.ts
@@ -4,7 +4,6 @@ import { Request } from "restify";
 import * as HttpStatus from "http-status-codes";
 import { IDatabaseProvider } from "../../db/idatabaseprovider";
 import { ILoggingProvider } from "../../logging/iLoggingProvider";
-import { ITelemProvider } from "../../telem/itelemprovider";
 import { sqlGenres } from "../../config/constants";
 
 /**
@@ -15,10 +14,8 @@ import { sqlGenres } from "../../config/constants";
 export class GenreController implements interfaces.Controller {
 
   constructor(@inject("IDatabaseProvider") private cosmosDb: IDatabaseProvider,
-              @inject("ITelemProvider") private telem: ITelemProvider,
               @inject("ILoggingProvider") private logger: ILoggingProvider) {
     this.cosmosDb = cosmosDb;
-    this.telem = telem;
     this.logger = logger;
   }
 

--- a/src/app/controllers/healthz.ts
+++ b/src/app/controllers/healthz.ts
@@ -3,7 +3,6 @@ import { Controller, Get, interfaces } from "inversify-restify-utils";
 import * as HttpStatus from "http-status-codes";
 import { IDatabaseProvider } from "../../db/idatabaseprovider";
 import { ILoggingProvider } from "../../logging/iLoggingProvider";
-import { ITelemProvider } from "../../telem/itelemprovider";
 import { sqlGenres, webInstanceRole, version } from "../../config/constants";
 import { DateUtilities } from "../../utilities/dateUtilities";
 
@@ -21,10 +20,8 @@ enum IetfStatus {
 export class HealthzController implements interfaces.Controller {
 
     constructor(@inject("IDatabaseProvider") private cosmosDb: IDatabaseProvider,
-                @inject("ITelemProvider") private telem: ITelemProvider,
                 @inject("ILoggingProvider") private logger: ILoggingProvider) {
         this.cosmosDb = cosmosDb;
-        this.telem = telem;
         this.logger = logger;
     }
 

--- a/src/app/controllers/movie.ts
+++ b/src/app/controllers/movie.ts
@@ -3,7 +3,6 @@ import { Controller, Get, interfaces } from "inversify-restify-utils";
 import * as HttpStatus from "http-status-codes";
 import { IDatabaseProvider } from "../../db/idatabaseprovider";
 import { ILoggingProvider } from "../../logging/iLoggingProvider";
-import { ITelemProvider } from "../../telem/itelemprovider";
 import { Movie } from "../models/movie";
 
 /**
@@ -14,10 +13,8 @@ import { Movie } from "../models/movie";
 export class MovieController implements interfaces.Controller {
 
     constructor(@inject("IDatabaseProvider") private cosmosDb: IDatabaseProvider,
-                @inject("ITelemProvider") private telem: ITelemProvider,
                 @inject("ILoggingProvider") private logger: ILoggingProvider) {
         this.cosmosDb = cosmosDb;
-        this.telem = telem;
         this.logger = logger;
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,12 +56,10 @@ import { version } from "./config/constants";
     iocContainer.bind<string>("string").toConstantValue(config.database).whenTargetNamed("database");
     iocContainer.bind<string>("string").toConstantValue(config.collection).whenTargetNamed("collection");
 
-    let telem: ITelemProvider;
     // AppInsightsProvider is optional
     if (config.insightsKey) {
         iocContainer.bind<string>("string").toConstantValue(config.insightsKey).whenTargetNamed("instrumentationKey");
         iocContainer.bind<ITelemProvider>("ITelemProvider").to(AppInsightsProvider).inSingletonScope();
-        telem = iocContainer.get<ITelemProvider>("ITelemProvider");
     }
 
     // initialize cosmos db provider

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,7 +61,7 @@ import { version } from "./config/constants";
     if (config.insightsKey) {
         iocContainer.bind<string>("string").toConstantValue(config.insightsKey).whenTargetNamed("instrumentationKey");
         iocContainer.bind<ITelemProvider>("ITelemProvider").to(AppInsightsProvider).inSingletonScope();
-        telem = iocContainer.get<ITelemProvider>("ITelemProvicer");
+        telem = iocContainer.get<ITelemProvider>("ITelemProvider");
     }
 
     // initialize cosmos db provider

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,7 +56,7 @@ import { version } from "./config/constants";
     iocContainer.bind<string>("string").toConstantValue(config.database).whenTargetNamed("database");
     iocContainer.bind<string>("string").toConstantValue(config.collection).whenTargetNamed("collection");
 
-    // AppInsightsProvider is optional
+    // ITelemProvicer/AppInsightsProvider is optional
     if (config.insightsKey) {
         iocContainer.bind<string>("string").toConstantValue(config.insightsKey).whenTargetNamed("instrumentationKey");
         iocContainer.bind<ITelemProvider>("ITelemProvider").to(AppInsightsProvider).inSingletonScope();

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,6 +56,7 @@ import { version } from "./config/constants";
     iocContainer.bind<string>("string").toConstantValue(config.database).whenTargetNamed("database");
     iocContainer.bind<string>("string").toConstantValue(config.collection).whenTargetNamed("collection");
 
+    // Note: the telem object is currently unused, but will be used with Key Rotation 
     let telem: ITelemProvider;
     // ITelemProvicer/AppInsightsProvider is optional
     if (config.insightsKey) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,10 +56,12 @@ import { version } from "./config/constants";
     iocContainer.bind<string>("string").toConstantValue(config.database).whenTargetNamed("database");
     iocContainer.bind<string>("string").toConstantValue(config.collection).whenTargetNamed("collection");
 
+    let telem: ITelemProvider;
     // ITelemProvicer/AppInsightsProvider is optional
     if (config.insightsKey) {
         iocContainer.bind<string>("string").toConstantValue(config.insightsKey).whenTargetNamed("instrumentationKey");
         iocContainer.bind<ITelemProvider>("ITelemProvider").to(AppInsightsProvider).inSingletonScope();
+        telem = iocContainer.get<ITelemProvider>("ITelemProvicer");
     }
 
     // initialize cosmos db provider

--- a/src/telem/appinsightsprovider.ts
+++ b/src/telem/appinsightsprovider.ts
@@ -1,6 +1,4 @@
 import * as ApplicationInsights from "applicationinsights";
-import { MetricTelemetry } from "applicationinsights/out/Declarations/Contracts";
-import { DependencyTelemetry } from "applicationinsights/out/Declarations/Contracts/TelemetryTypes/DependencyTelemetry";
 import { inject, injectable, named } from "inversify";
 
 /**
@@ -33,63 +31,10 @@ export class AppInsightsProvider {
 
     /**
      * Sends an event with the given name to App Insights
+     * Note: Currently unused, but will be used with Key Rotation
      * @param eventName Name of event to track
      */
     public trackEvent(eventName: string) {
         this.telemClient.trackEvent({name: eventName});
-    }
-
-    /**
-     * Send quantifiable metrics to App Insights
-     * TelemetryClient.TrackDependency class and properties:
-     *      https://docs.microsoft.com/en-us/dotnet/api/microsoft.applicationinsights
-     *      .datacontracts.dependencytelemetry?view=azure-dotnet
-     */
-
-    public trackDependency(dependency: DependencyTelemetry) {
-
-        this.telemClient.trackDependency(dependency);
-    }
-
-    public trackMetric(metric: MetricTelemetry) {
-
-        this.telemClient.trackMetric(metric);
-
-    }
-
-    public getDependencyTrackingObject(
-        dependencyTypeNameParam: string,
-        nameParam: string,
-        dataParam: string,
-        resultCodeParam: string,
-        successParam: boolean,
-        durationParam: number): DependencyTelemetry {
-
-        // Declare and initialize a DependencyTelemetry object for sending metrics to AppInsights
-        const dependencyTelem: DependencyTelemetry = {
-            dependencyTypeName: dependencyTypeNameParam,
-            name: nameParam,
-            data: dataParam,
-            resultCode: resultCodeParam,
-            success: successParam,
-            duration: durationParam,
-        };
-
-        // Return the DependencyTelemetry object
-        return dependencyTelem;
-    }
-
-    public getMetricTelemetryObject(
-        metricname: string,
-        metricvalue: number): MetricTelemetry {
-
-        // Declare and initialize a MetricTelemetry object for sending metrics to AppInsights
-        const metricTelem: MetricTelemetry = {
-            name: metricname,
-            value: metricvalue,
-        };
-
-        // Return the MetricTelemetry object
-        return metricTelem;
     }
 }

--- a/src/telem/itelemprovider.ts
+++ b/src/telem/itelemprovider.ts
@@ -1,26 +1,7 @@
-import { MetricTelemetry } from "applicationinsights/out/Declarations/Contracts";
-import { DependencyTelemetry } from "applicationinsights/out/Declarations/Contracts/TelemetryTypes/DependencyTelemetry";
-
 export interface ITelemProvider {
     /**
      * Sends an event with the given name to App Insights
      * @param eventName Name of event to track
      */
     trackEvent(eventName: string): void;
-
-    trackDependency(dependency: DependencyTelemetry): void;
-
-    trackMetric(metric: MetricTelemetry): void;
-
-    getDependencyTrackingObject(
-        dependencyTypeName: string,
-        name: string,
-        data: string,
-        resultCode: string,
-        success: boolean,
-        duration: number): DependencyTelemetry;
-
-    getMetricTelemetryObject(
-        name: string,
-        value: number): MetricTelemetry;
 }


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- Remove the un-used telemetry code and logging

## Review notes
- I decided to actually keep some of the telemetry code since we will be using the telemetry provider beyond starting default App Insights logging when we implement key rotation - i.e. logging "Key Rotated". (explained in comments too)
- Alternative would be to remove the itelemetryprovider and appinsightsprovider all together and just start app insights in server.ts -- something like:
if (config.insightsKey) {
     ApplicationInsights.setup(config.insightsKey)
        .setAutoDependencyCorrelation(true)
        .setAutoCollectRequests(true)
        .setAutoCollectPerformance(true)
        .setAutoCollectExceptions(true)
        .setAutoCollectDependencies(true)
        .setAutoCollectConsole(true)
        .setUseDiskRetryCaching(true)
        .start();
}
- I chose to keep using the ioc pattern so that it's easy to implement the custom Key Rotation event when the time comes, but am happy to remove for now if that's cleaner.

## Issues Closed or Referenced

- Closes #59 
