### PR TITLE
Handle Key Vault name and authtype as command line args 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,6 @@ Run the application locally
 
 # make sure you are in the root of the repo
 
-# set required keyvaultname environment variable
-export KeyVaultName={name of your key vault}
-
 # log in with azure credentials (if not done already)
 az login
 
@@ -93,8 +90,17 @@ az login
 # npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.1.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
 npm install
 
-# run the app
+# build the app
 npm run build
+
+# run the app with command line args
+# for local run, you need to specify CLI authentication type
+npm start -- --kvname {name of your keyvault} --authtype CLI
+
+# alternatively you can set the following environment variables and run without command line args
+export KeyVaultName={name of your keyvault}
+export AUTH_TYPE=CLI
+
 npm start
 
 # test the application
@@ -115,7 +121,12 @@ docker build -t helium-dev -f Dockerfile-Dev .
 # mount your ~/.azure directory to container root/.azure directory
 # you can also run the container and run az login from a bash shell
 # $He_Name is set to the name of your key vault
-docker run -d -p 4120:4120 -e KeyVaultName=$He_Name --name helium-dev -v ~/.azure:/root/.azure helium-dev "npm" "start"
+
+# option using command line args
+docker run -d -p 4120:4120 --name helium-dev -v ~/.azure:/root/.azure helium-dev "npm" "start" "--"  "--kvname" "${He_Name}" "--authtype" "CLI"
+
+# option using environment variables
+docker run -d -p 4120:4120 -e KeyVaultName=$He_Name -e AUTH_TYPE=CLI --name helium-dev -v ~/.azure:/root/.azure helium-dev "npm" "start"
 
 # check the logs
 # re-run until the application started message appears

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,12 +1,14 @@
 import { ILoggingProvider } from "../logging/iLoggingProvider";
 import { KeyVaultProvider } from "../secrets/keyvaultprovider";
 import {
-    keyVaultName, cosmosCollection, cosmosDatabase, cosmosKey, cosmosUrl,
+    cosmosCollection, cosmosDatabase, cosmosKey, cosmosUrl,
     appInsightsKey, portConstant,
 } from "./constants";
 
 // Gets configuration details needed to connect to KeyVault, CosmosDB, and AppInsights.
 export async function getConfigValues(
+    keyVaultUrl: string,
+    authType: string,
     log: ILoggingProvider): Promise<{
         port: string, cosmosDbKey: string, cosmosDbUrl: string,
         database: string, collection: string, insightsKey: string,
@@ -22,17 +24,7 @@ export async function getConfigValues(
     let collection: string;
     let insightsKey: string;
 
-    let keyVaultUrl: string = process.env[keyVaultName];
-    if (keyVaultUrl && !keyVaultUrl.startsWith("https://")) {
-        keyVaultUrl = "https://" + keyVaultUrl + ".vault.azure.net/";
-    }
-
-    if (!keyVaultUrl) {
-        log.Trace("Key Vault name missing: " + keyVaultUrl);
-        process.exit(1);
-    }
-
-    const keyvault: KeyVaultProvider = new KeyVaultProvider(keyVaultUrl, log);
+    const keyvault: KeyVaultProvider = new KeyVaultProvider(keyVaultUrl, authType, log);
 
     // get Cosmos DB related secrets
     try {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -10,6 +10,7 @@ export const appInsightsKey = "AppInsightsKey";
 export const portConstant = "4120";
 
 export const webInstanceRole = "WEBSITE_ROLE_INSTANCE_ID";
+export const authType = "AUTH_TYPE";
 
 export const version = VersionUtilities.getBuildVersion();
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -10,7 +10,7 @@ export const appInsightsKey = "AppInsightsKey";
 export const portConstant = "4120";
 
 export const webInstanceRole = "WEBSITE_ROLE_INSTANCE_ID";
-export const authType = "AUTH_TYPE";
+export const authTypeEnv = "AUTH_TYPE";
 
 export const version = VersionUtilities.getBuildVersion();
 

--- a/src/secrets/keyvaultprovider.ts
+++ b/src/secrets/keyvaultprovider.ts
@@ -1,5 +1,4 @@
 import { SecretClient } from "@azure/keyvault-secrets";
-import { webInstanceRole } from "../config/constants";
 import { inject, injectable } from "inversify";
 import { ILoggingProvider } from "../logging/iLoggingProvider";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
@@ -16,8 +15,10 @@ export class KeyVaultProvider {
      * @param url The KeyVault testing action URL
      */
     constructor(private url: string,
+                private authType: string,
                 @inject("ILoggingProvider") private logger: ILoggingProvider) {
         this.url = url;
+        this.authType = authType;
         this.logger = logger;
     }
 
@@ -51,8 +52,8 @@ export class KeyVaultProvider {
      */
     private async _initialize() {
 
-        // if web instance, use app service MSI, otherwise use az login credentials
-        const creds: any = process.env[webInstanceRole] ?
+        // Use specified authentication type (either MSI or CLI)
+        const creds: any = this.authType === "MSI" ?
             await msRestNodeAuth.loginWithAppServiceMSI({ resource: "https://vault.azure.net" }) :
             await msRestNodeAuth.AzureCliCredentials.create({ resource: "https://vault.azure.net" });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import { interfaces, InversifyRestifyServer, TYPE } from "inversify-restify-util
 import { ITelemProvider } from "./telem/itelemprovider";
 import { MovieController } from "./app/controllers/movie";
 import { robotsHandler } from "./middleware/robotsText";
-import { version } from "./config/constants";
+import { keyVaultName, version } from "./config/constants";
 
 (async () => {
     const restify = require("restify");
@@ -34,6 +34,34 @@ import { version } from "./config/constants";
     iocContainer.bind<ILoggingProvider>("ILoggingProvider").to(BunyanLogger).inSingletonScope();
     const log: ILoggingProvider = iocContainer.get<ILoggingProvider>("ILoggingProvider");
 
+    // Read command line args
+    let args = process.argv;
+    let keyVaultUri = process.env[keyVaultName];
+    let authType = process.env["AUTH_TYPE"] ? process.env["AUTH_TYPE"] : "MSI";
+    // log.Trace("args: " + args[2]); // + "," + args[1]);
+    if (args[2]){
+        for(let i = 2; i < args.length; i++){
+            if(args[i].startsWith("--authtype") && (i + 1) < args.length) {
+                authType = args[i + 1];
+                i++;
+            } else {
+                keyVaultUri = args[i];
+            }
+        }
+        log.Trace("authType: " + authType);
+        log.Trace("kvUri: " + keyVaultUri);
+    }
+    // function readCommandLineArgs():{ keyVaultUri: string, authType: string} {
+    //     let args = process.argv;
+    //     if (args != null) {
+    //         for (let i = 0; i < args.length; i++) {
+    //             if (args[i].startsWith("--")) {
+    
+    //             }
+    //         }
+    //     }
+    //     return { " ", " "};
+    // }
     // Get config values from Key Vault
     const config = await getConfigValues(log);
 

--- a/src/utilities/commandLineUtilities.ts
+++ b/src/utilities/commandLineUtilities.ts
@@ -1,0 +1,23 @@
+/**
+ * Utilities for handling command line arguments.
+ */
+export class CommandLineUtilities {
+
+    // Output CLI argument usage instructions to console
+    // Optional parameter to display error/context message
+    public static usage(message?: string) {
+        if (message) {
+            console.log(message);
+        }
+
+        console.log("\nUsage: npm start -- ...");
+        console.log("Required:");
+        console.log("\t--kvname Key Vault Name - name or full URL of the Azure Key Vault");
+        console.log("\t\t(can alternatively be set with environment variable KeyVaultName)");
+        console.log("Optional:");
+        console.log("\t[-h] [--help] - display command line usage");
+        console.log("\t[--authtype authentication type] - Valid types: ");
+        console.log("\t\t MSI - managed identity (default)");
+        console.log("\t\t CLI - Azure CLI cached credentials");
+    }
+}


### PR DESCRIPTION
## Type of PR

- [x] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- Update app to handle command line args and environment variables for authentication type and Key Vault name

## Review notes
- I could not find something for VS credentials in node sdks (can follow up with another PR if one is found)
- Tested locally and at anflinch.azurewebsites.net

## Issues Closed or Referenced

- Closes #75 
