### PR TITLE
Fixing Application Insights bug

### DIFF
--- a/src/HeliumServer.ts
+++ b/src/HeliumServer.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
 import EndpointLogger from "./middleware/EndpointLogger";
-import { DataService, TelemetryService, LogService } from "./services";
+import { DataService, LogService } from "./services";
 import { Container } from "inversify";
 import { InversifyRestifyServer } from "inversify-restify-utils";
 import { ConfigValues } from "./config/config";
@@ -13,15 +13,12 @@ import restify = require("restify");
 export class HeliumServer {
     private server: restify.Server;
     private inversifyServer: InversifyRestifyServer;
-    private telemetryService: TelemetryService;
     private dataService: DataService;
     private logService: LogService;
     private configValues: ConfigValues;
 
     constructor(private container: Container) {
         this.inversifyServer = new InversifyRestifyServer(this.container);
-        if (this.container.isBound("TelemetryService"))
-            this.container.get<TelemetryService>("TelemetryService")
         this.dataService = this.container.get<DataService>("DataService");
         this.logService = this.container.get<LogService>("LogService");
         this.configValues = this.container.get<ConfigValues>("ConfigValues");

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ import { CommandLineUtilities } from "./utilities";
     
     // retrieve configuration
     const config = await getConfigValues(args["keyvault-name"], args["auth-type"], logService);
-    if(!config) process.exit(-1);
+    if (!config) process.exit(-1);
 
     // setup ioc container
     container.bind<ConfigValues>("ConfigValues").toConstantValue(config);
@@ -35,6 +35,14 @@ import { CommandLineUtilities } from "./utilities";
     container.bind<DataService>("DataService").to(CosmosDBService).inSingletonScope();
     container.bind<TelemetryService>("TelemetryService").to(AppInsightsService).inSingletonScope();
     
+    // the telem object is currently unused, but will be used with Key Rotation
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let telemetryService: TelemetryService;
+    // telemetry service is optional
+    if (config.insightsKey) {
+        container.get<TelemetryService>("TelemetryService");
+    }
+
     // instantiate the server
     const heliumServer = new HeliumServer(container);
 

--- a/src/services/AppInsightsService.ts
+++ b/src/services/AppInsightsService.ts
@@ -12,10 +12,9 @@ export class AppInsightsService {
 
     /**
      * Creates a new instance of the App Insights client.
-     * @param instrumentationKey The key needed to register your app with App Insights
      */
     constructor(@inject("ConfigValues") configValues: ConfigValues) {
-        if(configValues.insightsKey) {
+        if (configValues.insightsKey) {
             // Setup Application insights with the automatic collection and dependency tracking enabled
             ApplicationInsights.setup(configValues.insightsKey)
                 .setAutoDependencyCorrelation(true)
@@ -38,7 +37,7 @@ export class AppInsightsService {
      * @param eventName Name of event to track
      */
     public trackEvent(eventName: string) {
-        if(this.telemetryClient)
+        if (this.telemetryClient)
             this.telemetryClient.trackEvent({ name: eventName });
     }
 }


### PR DESCRIPTION
## Type of PR

- [x] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
-  Over the weekend, sherbert stopped reporting data to its app insights instance, this happened due to some of the changes in the latest refactoring. 
-  Moving the instantiation of the app insights class to server.ts resolves the issue.

## Review notes
- Tested locally and deployed to app services and verified that data is flowing to App Insights with this change

## Issues Closed or Referenced

- References #124 
