### PR TITLE
Resolve "expected" HTTP 400 dependency failures in App Insights 

### DIFF
--- a/src/services/CosmosDBService.ts
+++ b/src/services/CosmosDBService.ts
@@ -13,7 +13,7 @@ export class CosmosDBService implements DataService {
 
     private cosmosClient: CosmosClient;
     private cosmosContainer: Container;
-    private feedOptions: FeedOptions = { maxItemCount: 2000 };
+    private feedOptions: FeedOptions = { maxItemCount: 2000, forceQueryPlan: true };
 
     // creates a new instance of the CosmosDB class.
     constructor(@inject("ConfigValues") private config: ConfigValues, @inject("LogService") private logger: LogService) {

--- a/src/services/CosmosDBService.ts
+++ b/src/services/CosmosDBService.ts
@@ -13,7 +13,7 @@ export class CosmosDBService implements DataService {
 
     private cosmosClient: CosmosClient;
     private cosmosContainer: Container;
-    private feedOptions: FeedOptions = { maxItemCount: 2000, forceQueryPlan: true };
+    private feedOptions: FeedOptions = { maxItemCount: 1000, forceQueryPlan: true };
 
     // creates a new instance of the CosmosDB class.
     constructor(@inject("ConfigValues") private config: ConfigValues, @inject("LogService") private logger: LogService) {


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- There is an issue/expected behavior with the Cosmos DB SDK, we previously saw this with C#, but they fixed the behavior in their latest version where there is a HTTP 400 response showing up as a dependency failure in App Insights.
- The 400 response is an intentional error in response to an query that cannot be served directly by the gateway. We handle this internally and it is not bubbled to the user. 
- The work around to avoid the misleading dependency failures is to set forceQueryPlan in FeedOptions to true. 


## Issues Closed or Referenced

- Closes #136 
