### PR TITLE
add workflow for issue triage and PR submitted automation

### DIFF
--- a/.github/workflows/open-issues-triage.yml
+++ b/.github/workflows/open-issues-triage.yml
@@ -1,0 +1,16 @@
+name: Move new issues into Triage
+
+on: [issues]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+    - name: add-new-issues-to-repository-based-project-column
+      uses: docker://takanabe/github-actions-automate-projects:latest
+      if: github.event_name == 'issues' && github.event.action == 'opened'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GIT_PAT_AUTO }}
+        GITHUB_PROJECT_URL: https://github.com/orgs/retaildevcrews/projects/1
+        GITHUB_PROJECT_COLUMN_NAME: Triage
+        DEBUG: true

--- a/.github/workflows/open-pr-submitted.yml
+++ b/.github/workflows/open-pr-submitted.yml
@@ -1,0 +1,16 @@
+name: Move assigned pull requests into PR Submitted / Review
+
+on: [pull_request]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+    - name: add-new-issues-to-repository-based-project-column
+      uses: docker://takanabe/github-actions-automate-projects:latest
+      if: github.event_name == 'pull_request' && github.event.action == 'opened'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GIT_PAT_AUTO }}
+        GITHUB_PROJECT_URL: https://github.com/orgs/retaildevcrews/projects/1
+        GITHUB_PROJECT_COLUMN_NAME: PR Submitted / Review
+        DEBUG: true


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [X] GitHub Template changes

## Purpose of PR
Auto update the helium Project board by placing new issues in Triage column and PRs into the PR Submitted Reviewed Column
## Review notes

## Issues Closed or Referenced

- References #210 
